### PR TITLE
Minor additions to the Real type

### DIFF
--- a/Forge.Utilities/Real.cs
+++ b/Forge.Utilities/Real.cs
@@ -365,6 +365,16 @@ namespace Forge.Utilities {
             return (int)(src.RawValue >> SHIFT_AMOUNT);
         }
 
+        public static explicit operator float(Real src)
+        {
+            return (float)src.RawValue / (float)One;
+        }
+
+        public static explicit operator double(Real src)
+        {
+            return (double)src.RawValue / (double)One;
+        }
+
         public static explicit operator Real(int src) {
             return Real.Create(src, true);
         }
@@ -532,12 +542,38 @@ namespace Forge.Utilities {
         }
         #endregion
 
-        #region Abs
+        #region Abs, Floor, Ceiling
         public static Real Abs(Real F) {
             if (F < 0)
                 return F.Inverse;
             else
                 return F;
+        }
+
+        public static Real Floor(Real F)
+        {
+            Real f2;
+            f2.RawValue = (F.RawValue >> SHIFT_AMOUNT) << SHIFT_AMOUNT;
+            return f2;
+        }
+
+        public static Real Ceiling(Real F)
+        {
+            Real f2;
+            f2.RawValue = ((F.RawValue >> SHIFT_AMOUNT) << SHIFT_AMOUNT) + One;
+            return f2;
+        }
+        #endregion
+        
+        #region Min, Max
+        public static Real Min(Real one, Real other)
+        {
+            return one.RawValue < other.RawValue ? one : other;
+        }
+
+        public static Real Max(Real one, Real other)
+        {
+            return one.RawValue > other.RawValue ? one : other;
         }
         #endregion
     }


### PR DESCRIPTION
``` c#
Real r = 5.5;
double d = (double)r;
// now d = 5, NOT 5.5
```

Because there was an explicit cast to int, but not float or double, attempting to cast to double used the int cast operator. Adding float & double cast operators seems like the safest solution.

These use the same code as the ToFloat and ToDouble properties.

In addition, I've added a few ultra-simple math functions:

``` c#
Real r1 = 57.8;
bool floor Real.Floor(r1) == 57;
bool ceil = Real.Ceiling(r1) == 58;

Real r2 = 52.1;
bool min = Real.Min(r1, r2) == 52.1;
bool max = Real.Max(r1, r2) == 57.8;

// floor, ceil, min, max are all true
```
